### PR TITLE
Fix curl request string

### DIFF
--- a/lib/fb/http_request.rb
+++ b/lib/fb/http_request.rb
@@ -81,7 +81,7 @@ module Fb
     def response
       @response ||= Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         curl_request = as_curl
-        p curl_request if Fb.configuration.developing?
+        print curl_request if Fb.configuration.developing?
         http.request http_request
       end
     end


### PR DESCRIPTION
use `print` instead of `p`. because we don't need `inspect` and escape " marks etc on the message.