### PR TITLE
Return nil, not error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ For more information about changelogs, check
 [Vandamme](http://tech-angels.github.io/vandamme).
 
 
+## 1.0.0.alpha6 - 2018-08-24
+
+* [BUGFIX] Do not raise error from `rate_limiting_header` when
+ response does not have the usage status header.
+
 ## 1.0.0.alpha5 - 2018-08-23
 
 * [FEATURE] Wait when usage status is approaching limit.

--- a/lib/fb/http_request.rb
+++ b/lib/fb/http_request.rb
@@ -45,7 +45,7 @@ module Fb
     # @raise [Fb::HTTPError] if the request fails.
     def run
       if response.is_a? @expected_response
-        if (waiting_time = self.class.waiting_time) &&
+        if (waiting_time = self.class.waiting_time) && rate_limiting_header &&
           rate_limiting_header.values.any? {|value| value > 85 }
           sleep waiting_time
         end
@@ -64,7 +64,8 @@ module Fb
 
     # @return [Hash] rate limit status in the response header.
     def rate_limiting_header
-      JSON response.to_hash['x-app-usage'][0]
+      usage = response.to_hash['x-app-usage']
+      JSON usage[0] if usage
     end
 
   private

--- a/lib/fb/support/version.rb
+++ b/lib/fb/support/version.rb
@@ -3,6 +3,6 @@ module Fb
   module Support
     # @return [String] the SemVer-compatible gem version.
     # @see http://semver.org
-    VERSION = '1.0.0.alpha5'
+    VERSION = '1.0.0.alpha6'
   end
 end


### PR DESCRIPTION
from `rate_limiting_header` method, when the response header does not have usage status part