### PR TITLE
Add on_response callback and remove waiting_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.0.0.alpha7 - 2019-01-15
+
+* Remove `waiting_time` and add `on_response` callback.
 
 ## 1.0.0.alpha6 - 2018-08-24
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,24 @@ Fb::Support provides:
 * [Fb::HTTPRequest](http://www.rubydoc.info/gems/fb-support/Fb/HTTPRequest)
 * [Fb::HTTPError](http://www.rubydoc.info/gems/fb-support/Fb/HTTPError)
 
-## Waiting Time
+## Response callback
 
-Facebook has [hourly rate limiting](https://developers.facebook.com/docs/graph-api/advanced/rate-limiting/#application-level-rate-limiting). `Fb::HTTPRequest` has `waiting_time` class variable
-to sleep the amount of time (in seconds) when it is approaching (with 85% of usage)
-in case the variable is set as follows.
+`Fb::HTTPRequest` has an `on_response` callback which is invoked with
+the HTTP response object on a successful response. This can be used for
+introspecting responses, performing some action when rate limit is near,
+etc.
 
 ```rb
-Fb::HTTPRequest.waiting_time = 360
+Fb::HTTPRequest.on_response = lambda { |res|
+  usage = res.fetch('x-app-usage', ['{}'])
+  parsed = JSON.parse(usage)
+  Librato.measure 'fb.call_count', parsed['call_count']
+  Librato.measure 'fb.total_cputime', parsed['total_cputime']
+  Librato.measure 'fb.total_time', parsed['total_time']
+  if parsed['call_count'] > 85
+    sleep 5
+  end
+}
 ```
 
 How to test

--- a/lib/fb/http_request.rb
+++ b/lib/fb/http_request.rb
@@ -35,9 +35,8 @@ module Fb
     end
 
     class << self
-      # @return [Integer] time in seconds for waiting when hourly rate limit
-      #   for the Facebook app reached over 85%
-      attr_accessor :waiting_time
+      # Callback invoked with the response object on a successful response. Defaults to a noop.
+      attr_accessor :on_response
     end
 
     # Sends the request and returns the response with the body parsed from JSON.
@@ -45,10 +44,7 @@ module Fb
     # @raise [Fb::HTTPError] if the request fails.
     def run
       if response.is_a? @expected_response
-        if (waiting_time = self.class.waiting_time) && rate_limiting_header &&
-          rate_limiting_header.values.any? {|value| value > 85 }
-          sleep waiting_time
-        end
+        self.class.on_response.call(response)
         response.tap do
           parse_response!
         end
@@ -115,3 +111,5 @@ module Fb
     end
   end
 end
+
+Fb::HTTPRequest.on_response = lambda {|_|}

--- a/lib/fb/http_request.rb
+++ b/lib/fb/http_request.rb
@@ -34,14 +34,19 @@ module Fb
       @params = options.fetch :params, {}
     end
 
-    class << self
-      @@on_response = lambda {|_|}
+    # Callback invoked with the response object on a successful response. Defaults to a noop.
+    # The callback invoked with two parameters: the HTTPRequest object
+    # and the Net::HTTP response object.
+    @@on_response = lambda {|_, _|}
 
-      # Callback invoked with the response object on a successful response. Defaults to a noop.
+    class << self
+
+      # Reader for @@on_response
       def on_response
         @@on_response
       end
 
+      # Writer for @@on_response
       def on_response=(callback)
         @@on_response = callback
       end
@@ -52,7 +57,7 @@ module Fb
     # @raise [Fb::HTTPError] if the request fails.
     def run
       if response.is_a? @expected_response
-        self.class.on_response.call(response)
+        self.class.on_response.call(self, response)
         response.tap do
           parse_response!
         end

--- a/lib/fb/http_request.rb
+++ b/lib/fb/http_request.rb
@@ -35,8 +35,16 @@ module Fb
     end
 
     class << self
+      @@on_response = lambda {|_|}
+
       # Callback invoked with the response object on a successful response. Defaults to a noop.
-      attr_accessor :on_response
+      def on_response
+        @@on_response
+      end
+
+      def on_response=(callback)
+        @@on_response = callback
+      end
     end
 
     # Sends the request and returns the response with the body parsed from JSON.
@@ -111,5 +119,3 @@ module Fb
     end
   end
 end
-
-Fb::HTTPRequest.on_response = lambda {|_|}

--- a/lib/fb/support/version.rb
+++ b/lib/fb/support/version.rb
@@ -3,6 +3,6 @@ module Fb
   module Support
     # @return [String] the SemVer-compatible gem version.
     # @see http://semver.org
-    VERSION = '1.0.0.alpha6'
+    VERSION = '1.0.0.alpha7'
   end
 end

--- a/spec/http_request_spec.rb
+++ b/spec/http_request_spec.rb
@@ -29,16 +29,21 @@ describe 'Fb::HTTPRequest#run' do
     let(:request) { Fb::HTTPRequest.new path: path, params: params }
 
     before do
-      @response = false
-      Fb::HTTPRequest.on_response = lambda { |res| @response = res }
+      @request = nil
+      @response = nil
+      Fb::HTTPRequest.on_response = lambda { |req, res|
+        @request = req
+        @response = res
+      }
     end
 
     after do
-      Fb::HTTPRequest.on_response = lambda {|_|}
+      Fb::HTTPRequest.on_response = lambda {|_,_|}
     end
 
     it 'calls the callback with the response object' do
       request.run
+      expect(@request).to be_a(Fb::HTTPRequest)
       expect(@response).to be_a(Net::HTTPOK)
     end
   end

--- a/spec/http_request_spec.rb
+++ b/spec/http_request_spec.rb
@@ -24,25 +24,22 @@ describe 'Fb::HTTPRequest#run' do
     end
   end
 
-  context 'given a valid request with rate limit almost all used' do
+  context 'given a valid request with a callback set' do
     let(:path) { '/v2.10/221406534569729' }
     let(:request) { Fb::HTTPRequest.new path: path, params: params }
 
     before do
-      allow_any_instance_of(Fb::HTTPRequest).to receive(:rate_limiting_header)
-        .and_return({"call_count"=>91, "total_cputime"=>0, "total_time"=>0})
-      Fb::HTTPRequest.waiting_time = 8
+      @response = false
+      Fb::HTTPRequest.on_response = lambda { |res| @response = res }
     end
 
     after do
-      Fb::HTTPRequest.waiting_time = nil
+      Fb::HTTPRequest.on_response = lambda {|_|}
     end
 
-    it 'sleeps for the waiting time' do
-      time1 = Time.now
+    it 'calls the callback with the response object' do
       request.run
-      time2 = Time.now
-      expect(time2 - time1).to be_within(1).of(8)
+      expect(@response).to be_a(Net::HTTPOK)
     end
   end
 end


### PR DESCRIPTION
Adds an `on_response` callback to `Fb::HTTPRequest` and removes
`waiting_time`. This can be used (as shown in the README) to implement
`waiting_time`'s behavior in the consuming application, while allowing
further flexibility.